### PR TITLE
ORDER BY clause pushdowning

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,18 @@ Which would yield something like:
 the rowid option is required. As are the names key and value for the columns.
 
 
+## Pushdowning
+
+#### ORDER BY push-down
+`etcd_fdw` now also supports order by push-down. If possible, push order by
+clause to the remote server so that we get the ordered result set from the
+foreign server itself.
+
+#### LIMIT push-down
+`etcd_fdw` now also supports limit offset push-down. Wherever possible,
+perform LIMIT operations on the remote server. 
+
+
 Usage
 -----
 


### PR DESCRIPTION
* ORDER BY clause pushdowning.
* mention supported push downs in the docs.

When turned on server debug logging you can see the difference.
```
 content":"key:\"\\000\" range_end:\"\\000\" sort_order:DESCEND sort_target:VALUE "}
```
```
 content":"key:\"\\000\" range_end:\"\\000\" "}
```