### PR TITLE
Add support for WHERE clause push-down

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ foreign server itself.
 `etcd_fdw` now also supports limit offset push-down. Wherever possible,
 perform LIMIT operations on the remote server. 
 
+#### WHERE push-down
+`etcd_fdw` now supports WHERE clause push-down for simple key-based comparisons. Whenever possible, equality and range conditions are translated into etcd key scans, so filtering is done on the remote server.
+Currently supported operators: `=`, `>=`, `>`, `<=`, `<`, `BETWEEN`, and `LIKE 'prefix%'`.
+This behavior is consistent with the prefix, range_end, and key options in `CREATE FOREIGN TABLE`.
 
 Usage
 -----


### PR DESCRIPTION
This PR contains following changes:
- Implements WHERE pushdown optimization feature. Currently supported operators: `=`, `>=`, `>`, `<=`, `<`, `BETWEEN`, and `LIKE 'prefix%'`.
- Readme changes for new feature.

This feature is consistent with FDW options in `CREATE FOREIGN TABLE`.

**Note:** For verification, I tried out multiple examples along with different create table options. I checked if `self.fetch_results` contained only filtered results at end of `begin_scan` function. The explain plan also showed no line `Rows Removed by Filter:` after the patch.

A few examples:

```sql
-- current result set
etcd_fdw=# SELECT * FROM test;
 key  |    value
------+-------------
 !    | hashvalue
 $    | dollarvalue
 123  | intvalue
 @    | atvalue
 abc  | abcvalue
 code | etcd_fdw
 foo  | foovalue
 key0 | value0
 key1 | value1
 key2 | value2
 key3 | value3
 key4 | value4
 key5 | value5
 key6 | value6
 key7 | value7
 key8 | value8
 key9 | value9
 zoo  | zoovalue
(18 rows)
```

**Without pushdown:**
```sql
-- explain plan without pushdown
etcd_fdw=# explain analyze SELECT * FROM test where key >= 'key1' and key < 'key5';
                                                                                                     QUERY PLAN

-------------------------------------------------------------------------------------------------------------------------------------
--------------------------------------------------------------------------------
 Foreign Scan on test  (cost=0.00..1.00 rows=1 width=0) (actual time=0.060..0.073 rows=4 loops=1)
   Filter: ((key >= 'key1'::text) AND (key < 'key5'::text))
   Rows Removed by Filter: 10
   Wrappers: quals = [Qual { field: "key", operator: ">=", value: Cell(String("key1")), use_or: false, param: None }, Qual { field: "
key", operator: "<", value: Cell(String("key5")), use_or: false, param: None }]
   Wrappers: tgts = [Column { name: "key", num: 1, type_oid: 25 }, Column { name: "value", num: 2, type_oid: 25 }]
   Wrappers: sorts = []
   Wrappers: limit = None
 Planning Time: 9.520 ms
 Execution Time: 6.513 ms
(9 rows)
```
**Note:** `Rows Removed by Filter: 10` in the plan.

**With pushdown:**
```sql
etcd_fdw=# SELECT * FROM test where key >= 'key1' and key < 'key5';
 key  | value
------+--------
 key1 | value1
 key2 | value2
 key3 | value3
 key4 | value4
(4 rows)

etcd_fdw=# explain analyze SELECT * FROM test where key >= 'key1' and key < 'key5';
                                                                                                     QUERY PLAN

-------------------------------------------------------------------------------------------------------------------------------------
--------------------------------------------------------------------------------
 Foreign Scan on test  (cost=0.00..1.00 rows=1 width=0) (actual time=0.037..0.048 rows=4 loops=1)
   Filter: ((key >= 'key1'::text) AND (key < 'key5'::text))
   Wrappers: quals = [Qual { field: "key", operator: ">=", value: Cell(String("key1")), use_or: false, param: None }, Qual { field: "
key", operator: "<", value: Cell(String("key5")), use_or: false, param: None }]
   Wrappers: tgts = [Column { name: "key", num: 1, type_oid: 25 }, Column { name: "value", num: 2, type_oid: 25 }]
   Wrappers: sorts = []
   Wrappers: limit = None
 Planning Time: 2.468 ms
 Execution Time: 3.740 ms
(8 rows)
```
Note no `Rows Removed by Filter:` in the plan.

Output with `range_end` option.

```sql
etcd_fdw=# CREATE foreign table test (key text, value text) server my_etcd_server options(rowid_column 'key', range_end 'key7');
CREATE FOREIGN TABLE
etcd_fdw=# SELECT * FROM test where key >= 'key3'; -- no rows after key6 since range_end is 'key7'
 key  | value
------+--------
 key3 | value3
 key4 | value4
 key5 | value5
 key6 | value6
(4 rows)

etcd_fdw=# explain analyze SELECT * FROM test where key >= 'key3';
                                                      QUERY PLAN
----------------------------------------------------------------------------------------------------------------------
 Foreign Scan on test  (cost=0.00..1.00 rows=1 width=0) (actual time=0.043..0.057 rows=4 loops=1)
   Filter: (key >= 'key3'::text)
   Wrappers: quals = [Qual { field: "key", operator: ">=", value: Cell(String("key3")), use_or: false, param: None }]
   Wrappers: tgts = [Column { name: "key", num: 1, type_oid: 25 }, Column { name: "value", num: 2, type_oid: 25 }]
   Wrappers: sorts = []
   Wrappers: limit = None
 Planning Time: 2.665 ms
 Execution Time: 4.027 ms
(8 rows)

-- LIKE
etcd_fdw=# explain analyze SELECT * FROM test where key like 'key%';
                                                      QUERY PLAN
----------------------------------------------------------------------------------------------------------------------
 Foreign Scan on test  (cost=0.00..1.00 rows=1 width=0) (actual time=0.028..0.042 rows=7 loops=1)
   Filter: (key ~~ 'key%'::text)
   Wrappers: quals = [Qual { field: "key", operator: "~~", value: Cell(String("key%")), use_or: false, param: None }]
   Wrappers: tgts = [Column { name: "key", num: 1, type_oid: 25 }, Column { name: "value", num: 2, type_oid: 25 }]
   Wrappers: sorts = []
   Wrappers: limit = None
 Planning Time: 2.593 ms
 Execution Time: 3.627 ms
(8 rows)

etcd_fdw=# SELECT * FROM test where key like 'key%';
 key  | value
------+--------
 key0 | value0
 key1 | value1
 key2 | value2
 key3 | value3
 key4 | value4
 key5 | value5
 key6 | value6
(7 rows)
```

Looking forward to feedback.