### PR TITLE
Change the repo for the `wrappers` crate to our fork of `supabase/wrappers` 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ pg_test = []
 etcd-client = { version = "0.16", features = ["tls"] }
 futures = "0.3.31"
 pgrx = {version="=0.16.1"}
-supabase-wrappers = { git="https://github.com/supabase/wrappers.git", tag="v0.5.7", default-features = false }
+supabase-wrappers = { git="https://github.com/cybertec-postgresql/wrappers.git", branch="develop", default-features = false }
 thiserror = "2.0.16"
 tokio = { version = "1.47.1", features = ["full"] }
 testcontainers = { version = "0.25.0", features = ["blocking"] }


### PR DESCRIPTION
As mentioned in #24 i've [forked](https://github.com/cybertec-postgresql/wrappers) supabase/wrappers and changed the log level of the warning that was spammed in the log to info. I've ran `cargo pgrx test` and everything still worked. 

Please check if this produces the expected results in the log and merge if it works :)

Thanks 