### PR TITLE
feat: support multiple comma-separated etcd endpoints in connstr

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,11 @@ This behavior is consistent with the prefix, range_end, and key options in `CREA
 
 - **connstr** as *string*, required
 
-  Connetion string for etcd server i.e. `127.0.0.1:2379`
+  Connection string for the etcd server, i.e. `127.0.0.1:2379`.
+
+  Multiple endpoints of an etcd cluster may be given as a comma-separated
+  list, i.e. `10.0.0.1:2379,10.0.0.2:2379,10.0.0.3:2379`. A single endpoint
+  (no comma) behaves exactly as before.
 
 - **ssl_key** as *string*, optional, no default
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,19 @@ fn parse_timeout(
     }
 }
 
-
+/// Parse the `connstr` server option into a list of etcd endpoints.
+///
+/// A single endpoint (no comma) yields a one-element list, preserving the
+/// original single-host configuration. Comma-separated values yield multiple
+/// endpoints; surrounding whitespace is trimmed and empty entries are dropped.
+fn parse_endpoints(connstr: &str) -> Vec<String> {
+    connstr
+        .split(',')
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
 
 /// Use this to connect to etcd.
 /// Parse the certs/key paths and read them as bytes
@@ -235,11 +247,17 @@ impl EtcdFdw {
 
 impl ForeignDataWrapper<EtcdFdwError> for EtcdFdw {
     fn new(server: ForeignServer) -> EtcdFdwResult<EtcdFdw> {
-        // Connection string for the etcd server (required).
+        // Connection string for the etcd server (required). It may list several
+        // comma-separated endpoints (e.g. '10.0.0.1:2379,10.0.0.2:2379'); a
+        // single endpoint keeps the original behavior.
         let connstr = match server.options.get("connstr") {
             Some(x) => x.clone(),
             None => return Err(EtcdFdwError::NoConnStr(())),
         };
+        let endpoints = parse_endpoints(&connstr);
+        if endpoints.is_empty() {
+            return Err(EtcdFdwError::NoConnStr(()));
+        }
 
         let cacert_path = server.options.get("ssl_ca").cloned();
         let cert_path = server.options.get("ssl_cert").cloned();
@@ -305,7 +323,7 @@ impl ForeignDataWrapper<EtcdFdwError> for EtcdFdw {
         }
 
         let config = EtcdConfig {
-            endpoints: vec![connstr],
+            endpoints,
             ca_cert_path: cacert_path,
             client_cert_path: cert_path,
             client_key_path: key_path,
@@ -1073,6 +1091,55 @@ mod tests {
         assert_eq!(
             (Some("o'clock".to_string()), Some("'quoted'".to_string())),
             row
+        );
+    }
+
+    // Multiple etcd endpoints: a comma-separated connstr must connect and work.
+    // The same reachable endpoint is listed twice so the multi-endpoint path is
+    // exercised deterministically without needing a real cluster. (Every other
+    // test uses a single endpoint, which confirms the old config still works.)
+    #[pg_test]
+    fn test_multiple_endpoints() {
+        let (_container, url) = create_container();
+        create_fdt(format!("{},{}", url, url));
+
+        Spi::run("INSERT INTO test (key, value) VALUES ('foo','bar')")
+            .expect("INSERT should work");
+        let value = Spi::get_one::<String>("SELECT value FROM test WHERE key='foo'")
+            .expect("SELECT should work");
+        assert_eq!(Some("bar".to_string()), value);
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::parse_endpoints;
+
+    #[test]
+    fn single_endpoint_unchanged() {
+        assert_eq!(
+            parse_endpoints("127.0.0.1:2379"),
+            vec!["127.0.0.1:2379".to_string()]
+        );
+    }
+
+    #[test]
+    fn multiple_endpoints_split() {
+        assert_eq!(
+            parse_endpoints("10.0.0.1:2379,10.0.0.2:2379,10.0.0.3:2379"),
+            vec![
+                "10.0.0.1:2379".to_string(),
+                "10.0.0.2:2379".to_string(),
+                "10.0.0.3:2379".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn trims_whitespace_and_drops_empty_entries() {
+        assert_eq!(
+            parse_endpoints(" a:1 , , b:2 ,"),
+            vec!["a:1".to_string(), "b:2".to_string()]
         );
     }
 }


### PR DESCRIPTION
## What

`connstr` now accepts a comma-separated list of etcd cluster endpoints:

```sql
CREATE SERVER s FOREIGN DATA WRAPPER etcd_fdw
  OPTIONS (connstr '10.0.0.1:2379,10.0.0.2:2379,10.0.0.3:2379');
```

The etcd client load-balances across the endpoints.

**Backward compatible:** a single endpoint (no comma) parses to a one-element list, so existing single-host configurations are unchanged.

## How

A small `parse_endpoints()` splits `connstr` on commas, trims each entry, and drops empty ones; the resulting `Vec<String>` is handed to `Client::connect` (which already supported multiple endpoints). `connstr` that yields no endpoints is rejected like a missing one.

## Tests

`cargo pgrx test` (PostgreSQL 17): **13/13 pass**, including:
- `unit_tests::single_endpoint_unchanged`, `multiple_endpoints_split`, `trims_whitespace_and_drops_empty_entries` — the parser;
- `test_multiple_endpoints` — drives the FDW end-to-end (INSERT/SELECT) through a comma-separated `connstr`;
- the 9 existing single-`connstr` tests, which confirm the old config still works.

---

Stacked on #36 (the segfault fix): the base is `fix/etcd-fdw-stability`, so this PR's diff shows only the multi-endpoint change. It can be retargeted to `main` once #36 merges.
